### PR TITLE
added live back

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,5 +1,5 @@
 const HDWalletProvider = require('@truffle/hdwallet-provider')
-require('dotenv').config();
+require('dotenv').config()
 
 const mnemonic = process.env.MNEMONIC
 const url = process.env.RPC_URL
@@ -17,6 +17,13 @@ module.exports = {
       network_id: '*',
     },
     kovan: {
+      provider: () => {
+        return new HDWalletProvider(mnemonic, url)
+      },
+      network_id: '42',
+      skipDryRun: true
+    },
+    live: {
       provider: () => {
         return new HDWalletProvider(mnemonic, url)
       },


### PR DESCRIPTION
and semicolons are gross

We have a number of blogs out there that use "live" in our box. Please keep it in, and just be the same as kovan. 